### PR TITLE
Develop upside down

### DIFF
--- a/everything-presence-pro.yaml
+++ b/everything-presence-pro.yaml
@@ -1237,9 +1237,9 @@ switch:
       inverted: FALSE
 
   - platform: template
-    name: "Upside Down Mounting"
+    name: "Upside Mounted"
     id: upside_down_mounting
-    restore_mode: RESTORE_DEFAULT_OFF
+    restore_mode: RESTORE_DEFAULT_ON
     optimistic: True
     entity_category: config
     icon: "mdi:rotate-180"


### PR DESCRIPTION
Because of the import of `packages:
   ld2450_common: github://everythingsmarthome/everything-presence-lite/common/ld2450-base.yaml@main`
   The upside down entity can't have two IDs with the same name on esphome, it prevents the toggle from working.
This is not a great solution as now two entities appear on HA.

Also noticed a bug on the addon (and probably the same exists in the map card) if the epl/ep pro is mounted upside down the sensor range cone also needs to be drawn flipped