### PR TITLE
feat(relay_contact_mode): able to change the relay from NO to NC - de…

### DIFF
--- a/common/everything-presence-pro-base.yaml
+++ b/common/everything-presence-pro-base.yaml
@@ -178,7 +178,7 @@ binary_sensor:
         - lambda: |-
             auto mode = id(system_alarm_mode).state;
             if (mode == "Presence Only" || mode == "Motion or Presence") {
-              bool activate = id(pir_motion).state;
+              bool activate = id(occupancy).state;
               bool desired = (id(relay_contact_mode).state == "Normally Open (NO)") ? activate : !activate;
               if (desired) {
                 id(system_alarm_relay).turn_on();


### PR DESCRIPTION
…faults to NO


 I don't know how to bind the `inverted` flag of the `switch` component to a `select`, so instead I opted for inverting the `id(system_alarm_relay).turn_on()` &  `id(system_alarm_relay).turn_off()` if the relay contact mode is in NC.