### PR TITLE
Fix occupancy OR logic

### DIFF
--- a/common/everything-presence-pro-base.yaml
+++ b/common/everything-presence-pro-base.yaml
@@ -187,15 +187,7 @@ binary_sensor:
     filters:
       - delayed_off: !lambda 'return id(occupancy_off_delay).state * 1000.0;'
     lambda: |-
-      if ( id(dfrobot_presence).state or id(pir_motion).state) {
-        return true;
-      }
-      else if (id(dfrobot_presence).state == 0 and id(pir_motion).state == 0) {
-        return false;
-      }
-      else {
-        return id(ld2450_occupancy).state;
-      }
+      return id(dfrobot_presence).state || id(pir_motion).state || id(ld2450_occupancy).state;
     on_state:
       then:
         - lambda: |-


### PR DESCRIPTION
Use all three presence sources in the EPP occupancy sensor instead of short-circuiting to `false` before LD2450 occupancy is checked.

Fixes #23